### PR TITLE
Updated query

### DIFF
--- a/src/shopify-selector.js
+++ b/src/shopify-selector.js
@@ -54,7 +54,7 @@ function getData(searchTerm, callback) {
             data: JSON.stringify({
                query: `
 {
-  products(first: 10, query: "title=${searchTerm}") {
+  products(first: 10, query: "title:${searchTerm}*") {
     edges {
       node {
         id


### PR DESCRIPTION
For me custom element was not working. Updated the query based on Shopify documentation: https://shopify.dev/api/usage/search-syntax#:~:text=of%20comparators%20is%3A-,%3A%20is%20equality*,-%3A%3C%20is%20less-than.

### Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
